### PR TITLE
Add Data and Typeable instances to KindID'

### DIFF
--- a/src/Data/KindID/Internal.hs
+++ b/src/Data/KindID/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -- |
 -- Module      : Data.KindID.Internal
@@ -13,11 +14,13 @@ import           Control.Monad.IO.Class
 import           Data.Aeson.Types hiding (String)
 import           Data.Binary
 import           Data.ByteString.Lazy (ByteString)
+import           Data.Data (Data)
 import           Data.Hashable
 import           Data.Proxy
 import           Data.KindID.Class
 import           Data.Text (Text)
 import qualified Data.Text as T
+import           Data.Typeable (Typeable)
 import           Data.TypeID.Class
 import           Data.TypeID.Error
 import           Data.TypeID.Internal (TypeID'(..))
@@ -38,7 +41,7 @@ import           System.Random
 -- It is dubbed 'Data.KindID.V7.KindID' because the prefix here is a data kind
 -- rather than a type.
 newtype KindID' (version :: UUIDVersion) prefix = KindID' UUID
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Data, Typeable)
 
 instance (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix))
   => Show (KindID' version prefix) where

--- a/src/Data/TypeID/Internal.hs
+++ b/src/Data/TypeID/Internal.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 -- |
 -- Module      : Data.TypeID.Internal
 -- License     : MIT
@@ -23,12 +25,14 @@ import qualified Data.ByteString as BS
 import           Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Char
+import           Data.Data (Data)
 import           Data.Hashable
 import           Data.Proxy
 import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Text.Encoding
+import           Data.Typeable (Typeable)
 import           Data.TypeID.Class
 import           Data.TypeID.Error
 import           Data.UUID.Types.Internal (UUID(..))
@@ -47,7 +51,7 @@ import           Foreign
 --  The constructor is not exposed to the public API to prevent generating
 -- invalid 'TypeID''s.
 data TypeID' (version :: UUIDVersion) = TypeID' Text UUID
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Data, Typeable)
 
 instance Show (TypeID' version) where
   show :: TypeID' version -> String


### PR DESCRIPTION
Hi,

This PR adds `Data` and `Typeable` instances for `KindID'` to enhance its usability in records that require those instances. 

Thanks for considering this contribution. 