### PR TITLE
Relax bytestring dependency

### DIFF
--- a/mmzk-typeid.cabal
+++ b/mmzk-typeid.cabal
@@ -99,7 +99,7 @@ library
         aeson >=2.1 && <3,
         array ^>=0.5,
         binary >=0.8.5 && <0.9,
-        bytestring ^>=0.11,
+        bytestring >=0.11 && < 0.13,
         entropy ^>=0.4,
         hashable ^>=1.4,
         random ^>=1.2,


### PR DESCRIPTION
`bytestring` [0.12.1.0](https://github.com/haskell/bytestring/releases/tag/0.12.1.0) was released in February but is excluded by the `^>=` constraint. This relaxed that bound to `< 0.13`. Tests still pass.