### PR TITLE
Add custom timestamp support for V7 UUID/TypeID/KindID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Revision history for mmzk-typeid
 
 
+## 0.7.1.0 -- UNRELEASED
+
+* Add custom timestamp support for V7 UUID/TypeID/KindID generation.
+  * New functions `genUUIDWithTime`, `genUUIDWithTime'`, and `genUUIDsWithTime` in `Data.UUID.V7`.
+  * New functions `genTypeIDWithTime`, `genTypeIDWithTime'`, and `genTypeIDsWithTime` in `Data.TypeID.V7` (and re-exported from `Data.TypeID`).
+  * New unsafe variants `unsafeGenTypeIDWithTime`, `unsafeGenTypeIDWithTime'`, and `unsafeGenTypeIDsWithTime` in `Data.TypeID.V7.Unsafe` (and re-exported from `Data.TypeID.Unsafe`).
+  * New functions `genKindIDWithTime`, `genKindIDWithTime'`, and `genKindIDsWithTime` in `Data.KindID.V7` (and re-exported from `Data.KindID`).
+  * These functions accept a `Word64` timestamp (milliseconds since Unix epoch) and do not interact with the global monotonic state.
+
+* More tests.
+
+
 ## 0.7.0.2 -- 2025-04-22
 
 * Fix a Haddock error on `ValidPrefix` related to conditional compilation.

--- a/mmzk-typeid.cabal
+++ b/mmzk-typeid.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.4
 name:               mmzk-typeid
-version:            0.7.0.2
+version:            0.7.1.0
 
 synopsis:           A TypeID and UUIDv7 implementation for Haskell
 description:

--- a/src/Data/KindID.hs
+++ b/src/Data/KindID.hs
@@ -49,6 +49,9 @@ module Data.KindID
   , genKindID
   , genKindID'
   , genKindIDs
+  , genKindIDWithTime
+  , genKindIDWithTime'
+  , genKindIDsWithTime
   , decorateKindID
   -- * 'KindID' generation (class methods)
   , genID

--- a/src/Data/KindID/Internal.hs
+++ b/src/Data/KindID/Internal.hs
@@ -358,6 +358,45 @@ genKindIDs n = fmap (unsafeFromTypeID <$>) . flip V7.unsafeGenTypeIDs n . T.pack
              $ symbolVal @(PrefixSymbol prefix) Proxy
 {-# INLINE genKindIDs #-}
 
+-- | Generate a new 'Data.KindID.V7.KindID' from a prefix with a custom
+-- timestamp (milliseconds since Unix epoch).
+genKindIDWithTime :: forall prefix m
+                   . ( ToPrefix prefix
+                     , ValidPrefix (PrefixSymbol prefix)
+                     , MonadIO m )
+                  => Word64 -> m (KindID' 'V7 prefix)
+genKindIDWithTime ts = unsafeFromTypeID
+  <$> V7.unsafeGenTypeIDWithTime (T.pack $ symbolVal @(PrefixSymbol prefix) Proxy) ts
+{-# INLINE genKindIDWithTime #-}
+
+-- | Generate a new 'Data.KindID.V7.KindID' from a prefix with a custom
+-- timestamp based on stateless 'UUID'v7.
+genKindIDWithTime' :: forall prefix m
+                    . ( ToPrefix prefix
+                      , ValidPrefix (PrefixSymbol prefix)
+                      , MonadIO m )
+                   => Word64 -> m (KindID' 'V7 prefix)
+genKindIDWithTime' ts = fmap unsafeFromTypeID
+  . flip V7.unsafeGenTypeIDWithTime' ts . T.pack
+  $ symbolVal @(PrefixSymbol prefix) Proxy
+{-# INLINE genKindIDWithTime' #-}
+
+-- | Generate a list of 'Data.KindID.V7.KindID's from a prefix with a custom
+-- timestamp (milliseconds since Unix epoch).
+--
+-- The first 32768 'Data.KindID.V7.KindID's are guaranteed to be monotonically
+-- increasing.
+genKindIDsWithTime :: forall prefix m
+                    . ( ToPrefix prefix
+                      , ValidPrefix (PrefixSymbol prefix)
+                      , MonadIO m )
+                   => Word64 -> Word16 -> m [KindID' 'V7 prefix]
+genKindIDsWithTime ts n
+  = fmap (unsafeFromTypeID <$>)
+  . (\p -> V7.unsafeGenTypeIDsWithTime p ts n) . T.pack
+  $ symbolVal @(PrefixSymbol prefix) Proxy
+{-# INLINE genKindIDsWithTime #-}
+
 -- | Generate a new 'KindID'' ''V1' from a prefix.
 --
 -- It throws a 'TypeIDError' if the prefix does not match the specification,

--- a/src/Data/KindID/V7.hs
+++ b/src/Data/KindID/V7.hs
@@ -19,6 +19,9 @@ module Data.KindID.V7
   , genKindID
   , genKindID'
   , genKindIDs
+  , genKindIDWithTime
+  , genKindIDWithTime'
+  , genKindIDsWithTime
   , decorateKindID
   -- * 'KindID' generation (class methods)
   , genID
@@ -104,6 +107,29 @@ genKindIDs :: (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix), MonadIO m)
            => Word16 -> m [KindID prefix]
 genKindIDs = KID.genKindIDs
 {-# INLINE genKindIDs #-}
+
+-- | Generate a new 'KindID' from a prefix with a custom timestamp
+-- (milliseconds since Unix epoch).
+genKindIDWithTime :: (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix), MonadIO m)
+                  => Word64 -> m (KindID prefix)
+genKindIDWithTime = KID.genKindIDWithTime
+{-# INLINE genKindIDWithTime #-}
+
+-- | Generate a new 'KindID' from a prefix with a custom timestamp based on
+-- stateless 'UUID'v7.
+genKindIDWithTime' :: (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix), MonadIO m)
+                   => Word64 -> m (KindID prefix)
+genKindIDWithTime' = KID.genKindIDWithTime'
+{-# INLINE genKindIDWithTime' #-}
+
+-- | Generate a list of 'KindID's from a prefix with a custom timestamp
+-- (milliseconds since Unix epoch).
+--
+-- The first 32768 'KindID's are guaranteed to be monotonically increasing.
+genKindIDsWithTime :: (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix), MonadIO m)
+                   => Word64 -> Word16 -> m [KindID prefix]
+genKindIDsWithTime = KID.genKindIDsWithTime
+{-# INLINE genKindIDsWithTime #-}
 
 -- | Obtain a 'KindID' from a prefix and a 'UUID'.
 decorateKindID :: (ToPrefix prefix, ValidPrefix (PrefixSymbol prefix))

--- a/src/Data/TypeID.hs
+++ b/src/Data/TypeID.hs
@@ -21,6 +21,9 @@ module Data.TypeID
   , genTypeID
   , genTypeID'
   , genTypeIDs
+  , genTypeIDWithTime
+  , genTypeIDWithTime'
+  , genTypeIDsWithTime
   , decorateTypeID
   -- * 'TypeID' generation (class methods)
   , genID

--- a/src/Data/TypeID/Internal.hs
+++ b/src/Data/TypeID/Internal.hs
@@ -647,6 +647,63 @@ unsafeGenTypeIDs :: MonadIO m => Text -> Word16 -> m [TypeID' 'V7]
 unsafeGenTypeIDs prefix n = map (TypeID' prefix) <$> V7.genUUIDs n
 {-# INLINE unsafeGenTypeIDs #-}
 
+-- | Generate a new 'Data.TypeID.V7.TypeID' from a prefix with a custom
+-- timestamp (milliseconds since Unix epoch).
+--
+-- It throws a 'TypeIDError' if the prefix does not match the specification,
+-- namely if it's longer than 63 characters or if it contains characters other
+-- than lowercase latin letters.
+genTypeIDWithTime :: MonadIO m => Text -> Word64 -> m (TypeID' 'V7)
+genTypeIDWithTime prefix ts = case checkPrefix prefix of
+  Nothing  -> unsafeGenTypeIDWithTime prefix ts
+  Just err -> liftIO $ throwIO err
+{-# INLINE genTypeIDWithTime #-}
+
+-- | Generate a new 'Data.TypeID.V7.TypeID' from a prefix with a custom
+-- timestamp based on stateless 'UUID'v7.
+--
+-- See the documentation of 'V7.genUUIDWithTime'' for more information.
+genTypeIDWithTime' :: MonadIO m => Text -> Word64 -> m (TypeID' 'V7)
+genTypeIDWithTime' prefix ts = case checkPrefix prefix of
+  Nothing  -> unsafeGenTypeIDWithTime' prefix ts
+  Just err -> liftIO $ throwIO err
+{-# INLINE genTypeIDWithTime' #-}
+
+-- | Generate a list of 'Data.TypeID.V7.TypeID's from a prefix with a custom
+-- timestamp (milliseconds since Unix epoch).
+--
+-- The first 32768 'Data.TypeID.V7.TypeID's are guaranteed to be monotonically
+-- increasing.
+genTypeIDsWithTime :: MonadIO m => Text -> Word64 -> Word16 -> m [TypeID' 'V7]
+genTypeIDsWithTime prefix ts n = case checkPrefix prefix of
+  Nothing  -> unsafeGenTypeIDsWithTime prefix ts n
+  Just err -> liftIO $ throwIO err
+{-# INLINE genTypeIDsWithTime #-}
+
+-- | Generate a new 'Data.TypeID.V7.TypeID' from a prefix with a custom
+-- timestamp, but without checking if the prefix is valid.
+unsafeGenTypeIDWithTime :: MonadIO m => Text -> Word64 -> m (TypeID' 'V7)
+unsafeGenTypeIDWithTime prefix ts = TypeID' prefix <$> V7.genUUIDWithTime ts
+{-# INLINE unsafeGenTypeIDWithTime #-}
+
+-- | Generate a new 'Data.TypeID.V7.TypeID' from a prefix with a custom
+-- timestamp based on stateless 'UUID'v7, but without checking if the prefix
+-- is valid.
+unsafeGenTypeIDWithTime' :: MonadIO m => Text -> Word64 -> m (TypeID' 'V7)
+unsafeGenTypeIDWithTime' prefix ts = TypeID' prefix <$> V7.genUUIDWithTime' ts
+{-# INLINE unsafeGenTypeIDWithTime' #-}
+
+-- | Generate n 'Data.TypeID.V7.TypeID's from a prefix with a custom timestamp,
+-- but without checking if the prefix is valid.
+--
+-- The first 32768 'Data.TypeID.V7.TypeID's are guaranteed to be monotonically
+-- increasing.
+unsafeGenTypeIDsWithTime :: MonadIO m
+                         => Text -> Word64 -> Word16 -> m [TypeID' 'V7]
+unsafeGenTypeIDsWithTime prefix ts n
+  = map (TypeID' prefix) <$> V7.genUUIDsWithTime ts n
+{-# INLINE unsafeGenTypeIDsWithTime #-}
+
 -- | Parse a 'TypeID'' from its 'String' representation, but crashes when
 -- parsing fails.
 unsafeParseString :: String -> TypeID' version

--- a/src/Data/TypeID/Unsafe.hs
+++ b/src/Data/TypeID/Unsafe.hs
@@ -14,6 +14,10 @@ module Data.TypeID.Unsafe
     unsafeGenTypeID
   , unsafeGenTypeID'
   , unsafeGenTypeIDs
+  -- * Unsafe 'Data.TypeID.V7.TypeID' generation with custom timestamp
+  , unsafeGenTypeIDWithTime
+  , unsafeGenTypeIDWithTime'
+  , unsafeGenTypeIDsWithTime
   -- * Unsafe decoding ('Data.TypeID.V7.TypeID'-specific)
   , unsafeParseString
   , unsafeParseText

--- a/src/Data/TypeID/V7.hs
+++ b/src/Data/TypeID/V7.hs
@@ -19,6 +19,9 @@ module Data.TypeID.V7
   , genTypeID
   , genTypeID'
   , genTypeIDs
+  , genTypeIDWithTime
+  , genTypeIDWithTime'
+  , genTypeIDsWithTime
   , decorateTypeID
   -- * 'TypeID' generation (class methods)
   , genID
@@ -96,6 +99,32 @@ genTypeID' = TID.genTypeID'
 genTypeIDs :: MonadIO m => Text -> Word16 -> m [TypeID]
 genTypeIDs = TID.genTypeIDs
 {-# INLINE genTypeIDs #-}
+
+-- | Generate a new 'TypeID' from a prefix with a custom timestamp
+-- (milliseconds since Unix epoch).
+--
+-- It throws a 'TypeIDError' if the prefix does not match the specification,
+-- namely if it's longer than 63 characters or if it contains characters other
+-- than lowercase latin letters.
+genTypeIDWithTime :: MonadIO m => Text -> Word64 -> m TypeID
+genTypeIDWithTime = TID.genTypeIDWithTime
+{-# INLINE genTypeIDWithTime #-}
+
+-- | Generate a new 'TypeID' from a prefix with a custom timestamp based on
+-- stateless 'UUID'v7.
+--
+-- See the documentation of 'V7.genUUIDWithTime'' for more information.
+genTypeIDWithTime' :: MonadIO m => Text -> Word64 -> m TypeID
+genTypeIDWithTime' = TID.genTypeIDWithTime'
+{-# INLINE genTypeIDWithTime' #-}
+
+-- | Generate a list of 'TypeID's from a prefix with a custom timestamp
+-- (milliseconds since Unix epoch).
+--
+-- The first 32768 'TypeID's are guaranteed to be monotonically increasing.
+genTypeIDsWithTime :: MonadIO m => Text -> Word64 -> Word16 -> m [TypeID]
+genTypeIDsWithTime = TID.genTypeIDsWithTime
+{-# INLINE genTypeIDsWithTime #-}
 
 -- | Obtain a 'TypeID' from a prefix and a 'UUID'.
 decorateTypeID :: Text -> UUID -> Either TypeIDError TypeID

--- a/src/Data/TypeID/V7/Unsafe.hs
+++ b/src/Data/TypeID/V7/Unsafe.hs
@@ -12,6 +12,10 @@ module Data.TypeID.V7.Unsafe
     unsafeGenTypeID
   , unsafeGenTypeID'
   , unsafeGenTypeIDs
+  -- * Unsafe 'TypeID' generation with custom timestamp
+  , unsafeGenTypeIDWithTime
+  , unsafeGenTypeIDWithTime'
+  , unsafeGenTypeIDsWithTime
   -- * Unsafe decoding ('TypeID'-specific)
   , unsafeParseString
   , unsafeParseText
@@ -55,6 +59,28 @@ unsafeGenTypeID' = TID.unsafeGenTypeID'
 unsafeGenTypeIDs :: MonadIO m => Text -> Word16 -> m [TypeID]
 unsafeGenTypeIDs = TID.unsafeGenTypeIDs
 {-# INLINE unsafeGenTypeIDs #-}
+
+-- | Generate a new 'TypeID' from a prefix with a custom timestamp
+-- (milliseconds since Unix epoch), but without checking if the prefix is
+-- valid.
+unsafeGenTypeIDWithTime :: MonadIO m => Text -> Word64 -> m TypeID
+unsafeGenTypeIDWithTime = TID.unsafeGenTypeIDWithTime
+{-# INLINE unsafeGenTypeIDWithTime #-}
+
+-- | Generate a new 'TypeID' from a prefix with a custom timestamp based on
+-- stateless 'Data.UUID.Types.Internal.UUID'v7, but without checking if the
+-- prefix is valid.
+unsafeGenTypeIDWithTime' :: MonadIO m => Text -> Word64 -> m TypeID
+unsafeGenTypeIDWithTime' = TID.unsafeGenTypeIDWithTime'
+{-# INLINE unsafeGenTypeIDWithTime' #-}
+
+-- | Generate n 'TypeID's from a prefix with a custom timestamp, but without
+-- checking if the prefix is valid.
+--
+-- The first 32768 'TypeID's are guaranteed to be monotonically increasing.
+unsafeGenTypeIDsWithTime :: MonadIO m => Text -> Word64 -> Word16 -> m [TypeID]
+unsafeGenTypeIDsWithTime = TID.unsafeGenTypeIDsWithTime
+{-# INLINE unsafeGenTypeIDsWithTime #-}
 
 -- | Parse a 'TypeID' from its 'String' representation, but crashes when
 -- parsing fails.

--- a/src/Data/UUID/V7.hs
+++ b/src/Data/UUID/V7.hs
@@ -17,6 +17,10 @@ module Data.UUID.V7
   , genUUID
   , genUUID'
   , genUUIDs
+  -- * 'UUID'v7 generation with custom timestamp
+  , genUUIDWithTime
+  , genUUIDWithTime'
+  , genUUIDsWithTime
   -- * Validation
   , validate
   , validateWithTime
@@ -52,15 +56,7 @@ genUUID = head <$> genUUIDs 1
 -- In use cases where the ordering is not important, this function is could be
 -- preferred.
 genUUID' :: MonadIO m => m UUID
-genUUID' = do
-  timestamp <- getEpochMilli
-  entropy16 <- getEntropyWord16
-  entropy64 <- getEntropyWord64
-  let bs = runPut do
-        fillTime timestamp
-        fillVerAndRandA entropy16
-        fillVarAndRandB entropy16 entropy64
-  pure . uncurry UUID $ runGet (join (liftM2 (,)) getWord64be) bs
+genUUID' = getEpochMilli >>= genUUIDWithTime'
 {-# INLINE genUUID' #-}
 
 -- | Generate a list of 'UUID'v7s.
@@ -108,6 +104,58 @@ genUUIDs = liftIO . go True
           if n' == n
             then pure uuids
             else (uuids ++) <$> go False (n - n')
+
+-- | Generate a 'UUID'v7 with a custom timestamp (milliseconds since Unix
+-- epoch).
+--
+-- It does not interact with the global state, so it is safe to interleave
+-- with 'genUUID'.
+genUUIDWithTime :: MonadIO m => Word64 -> m UUID
+genUUIDWithTime ts = head <$> genUUIDsWithTime ts 1
+{-# INLINE genUUIDWithTime #-}
+
+-- | Generate a stateless 'UUID'v7 with a custom timestamp (milliseconds since
+-- Unix epoch).
+--
+-- It is faster than 'genUUIDWithTime' but it is not guaranteed to be
+-- monotonically increasing if multiple 'UUID's are generated with the same
+-- timestamp.
+genUUIDWithTime' :: MonadIO m => Word64 -> m UUID
+genUUIDWithTime' timestamp = do
+  entropy16 <- getEntropyWord16
+  entropy64 <- getEntropyWord64
+  let bs = runPut do
+        fillTime timestamp
+        fillVerAndRandA entropy16
+        fillVarAndRandB entropy16 entropy64
+  pure . uncurry UUID $ runGet (join (liftM2 (,)) getWord64be) bs
+{-# INLINE genUUIDWithTime' #-}
+
+-- | Generate a list of 'UUID'v7s with a custom timestamp (milliseconds since
+-- Unix epoch).
+--
+-- The first 32768 'UUID's are guaranteed to be monotonically increasing.
+--
+-- It does not interact with the global state, so it is safe to interleave
+-- with 'genUUIDs'.
+genUUIDsWithTime :: MonadIO m => Word64 -> Word16 -> m [UUID]
+genUUIDsWithTime timestamp = liftIO . go
+  where
+    go 0 = pure []
+    go n = do
+      entropy16 <- (.&. 0x7FFF) <$> getEntropyWord16
+      let slots = min n (0xFFFF - entropy16)
+      uuids <- forM [0..(slots - 1)] \curN -> do
+        entropy64 <- getEntropyWord64
+        let seqNo = entropy16 + curN
+            bs = runPut do
+              fillTime timestamp
+              fillVerAndRandA seqNo
+              fillVarAndRandB seqNo entropy64
+        pure . uncurry UUID $ runGet (join (liftM2 (,)) getWord64be) bs
+      if slots == n
+        then pure uuids
+        else (uuids ++) <$> go (n - slots)
 
 -- | Validate the version and variant of the 'UUID'v7.
 validate :: UUID -> Bool

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -113,6 +113,7 @@ main :: IO ()
 main = hspec do
   typeLevelTest
   v7Test
+  v7WithTimeTest
   v1Test
   v4Test
   v5Test
@@ -364,6 +365,73 @@ v7Test = do
         kid'' <- peek ptr
         kid'' `shouldBe` kid'
         free ptr
+
+v7WithTimeTest :: Spec
+v7WithTimeTest = do
+  let testTimestamp = 1234567890123 :: Word64
+  describe "Generate TypeID with custom timestamp" do
+    it "can generate TypeID with correct prefix and timestamp" do
+      tid <- genTypeIDWithTime "mmzk" testTimestamp
+      getPrefix tid `shouldBe` "mmzk"
+      getTime tid `shouldBe` testTimestamp
+      validateWithVersion (getUUID tid) V7 `shouldBe` True
+    it "can generate TypeID with stateless UUIDv7 and custom timestamp" do
+      tid <- genTypeIDWithTime' "mmzk" testTimestamp
+      getPrefix tid `shouldBe` "mmzk"
+      getTime tid `shouldBe` testTimestamp
+      validateWithVersion (getUUID tid) V7 `shouldBe` True
+    it "can generate batch with same custom timestamp and ascending order" do
+      tids <- genTypeIDsWithTime "mmzk" testTimestamp 100
+      all ((== "mmzk") . getPrefix) tids `shouldBe` True
+      all ((== testTimestamp) . getTime) tids `shouldBe` True
+      all (\tid -> validateWithVersion (getUUID tid) V7) tids `shouldBe` True
+      all (uncurry (<)) (zip tids $ tail tids) `shouldBe` True
+    it "rejects invalid prefix" do
+      genTypeIDWithTime "INVALID" testTimestamp `shouldThrow` anyTypeIDError
+    it "works with timestamp 0" do
+      tid <- genTypeIDWithTime "mmzk" 0
+      getPrefix tid `shouldBe` "mmzk"
+      getTime tid `shouldBe` 0
+      validateWithVersion (getUUID tid) V7 `shouldBe` True
+  describe "Generate KindID with custom timestamp" do
+    it "can generate KindID with correct prefix and timestamp" do
+      kid <- genKindIDWithTime @"mmzk" testTimestamp
+      getPrefix kid `shouldBe` "mmzk"
+      getTime kid `shouldBe` testTimestamp
+      validateWithVersion (getUUID kid) V7 `shouldBe` True
+    it "can generate KindID with stateless UUIDv7 and custom timestamp" do
+      kid <- genKindIDWithTime' @"mmzk" testTimestamp
+      getPrefix kid `shouldBe` "mmzk"
+      getTime kid `shouldBe` testTimestamp
+      validateWithVersion (getUUID kid) V7 `shouldBe` True
+    it "can generate KindID batch with same custom timestamp and ascending order" do
+      kids <- genKindIDsWithTime @"mmzk" testTimestamp 100
+      all ((== "mmzk") . getPrefix) kids `shouldBe` True
+      all ((== testTimestamp) . getTime) kids `shouldBe` True
+      all (\kid -> validateWithVersion (getUUID kid) V7) kids `shouldBe` True
+      all (uncurry (<)) (zip kids $ tail kids) `shouldBe` True
+  describe "Generate UUID with custom timestamp" do
+    it "can generate UUID with correct timestamp" do
+      uuid <- V7.genUUIDWithTime testTimestamp
+      V7.getTime uuid `shouldBe` testTimestamp
+      V7.validate uuid `shouldBe` True
+    it "can generate stateless UUID with correct timestamp" do
+      uuid <- V7.genUUIDWithTime' testTimestamp
+      V7.getTime uuid `shouldBe` testTimestamp
+      V7.validate uuid `shouldBe` True
+    it "can generate UUID batch with same timestamp and ascending order" do
+      uuids <- V7.genUUIDsWithTime testTimestamp 100
+      all ((== testTimestamp) . V7.getTime) uuids `shouldBe` True
+      all V7.validate uuids `shouldBe` True
+      all (uncurry (<)) (zip uuids $ tail uuids) `shouldBe` True
+  describe "Custom timestamp does not affect global state" do
+    it "does not interfere with normal generation" do
+      tid1 <- genID @TypeID "test"
+      let ts1 = getTime tid1
+      _    <- genTypeIDWithTime "test" 0
+      tid2 <- genID @TypeID "test"
+      let ts2 = getTime tid2
+      ts2 `shouldSatisfy` (>= ts1)
 
 v1Test :: Spec
 v1Test = do


### PR DESCRIPTION
## Summary

Adds functions for generating V7 UUIDs, TypeIDs, and KindIDs with a caller-supplied
timestamp instead of reading the system clock.

### Motivation

When adopting TypeIDs for an existing resource that already has a `created_at` timestamp,
it's useful to generate IDs that sort consistently with the original creation order.
These functions make it possible to backfill TypeIDs using historical timestamps so that
the natural sort order of the IDs matches the existing chronological order of the data.

### New API surface

**`Data.UUID.V7`**
- `genUUIDWithTime` — monotonic, uses internal sequence counter
- `genUUIDWithTime'` — stateless, faster but no monotonicity guarantee
- `genUUIDsWithTime` — batch generation (first 32768 guaranteed monotonic)

**`Data.TypeID.V7`** (re-exported from `Data.TypeID`)
- `genTypeIDWithTime`, `genTypeIDWithTime'`, `genTypeIDsWithTime`

**`Data.TypeID.V7.Unsafe`** (re-exported from `Data.TypeID.Unsafe`)
- `unsafeGenTypeIDWithTime`, `unsafeGenTypeIDWithTime'`, `unsafeGenTypeIDsWithTime`

**`Data.KindID.V7`** (re-exported from `Data.KindID`)
- `genKindIDWithTime`, `genKindIDWithTime'`, `genKindIDsWithTime`

### Design notes

- The `WithTime` functions accept a `Word64` timestamp (milliseconds since Unix epoch),
  matching the existing `getTime` return type.
- Custom-timestamp generation does not interact with the global monotonic state, so it
  is safe to interleave with normal `genUUID`/`genTypeID`/`genKindID` calls.
- `genUUID'` was refactored to delegate to `genUUIDWithTime'`, eliminating duplication.
- Follows the existing naming convention (`gen*WithTime` paralleling `gen*`).

### Tests

- Verifies correct prefix, timestamp, UUID version/variant for all new functions
- Batch monotonicity for `genTypeIDsWithTime`, `genKindIDsWithTime`, `genUUIDsWithTime`
- Invalid prefix rejection
- Edge case: timestamp 0
- Confirms custom-timestamp generation does not affect global monotonic state

### Version & changelog

Bumps version to `0.7.1.0` and adds a changelog entry. Happy to remove this commit
if you'd prefer to handle versioning separately.

## Attribution

This PR was developed with AI assistance (Claude, Anthropic).