### PR TITLE
Support random-1.2, ghc-9.14

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        ghc: [9.4.8, 9.6.4, 9.8.2, 9.12.2]
+        ghc: [9.4.8, 9.6.7, 9.8.4, 9.12.4, 9.14.1]
     steps:
       - uses: actions/checkout@v4
       - uses: haskell-actions/setup@v2

--- a/mmzk-typeid.cabal
+++ b/mmzk-typeid.cabal
@@ -104,7 +104,7 @@ library
         bytestring >=0.11 && <0.13,
         entropy ^>=0.4,
         hashable >=1.4 && <2,
-        random ^>=1.2,
+        random >=1.2 && <1.4,
         text ^>=2.1,
         time >=1.11 && <2,
         uuid ^>=1.3,


### PR DESCRIPTION
Tested using

    cabal test -c 'aeson>=2.2' -c 'binary>=0.8.9' -c 'bytestring>=0.12' -c 'random>=1.3' -w ghc-9.14.1

Fixes #11